### PR TITLE
fix: remove starting the week with a contribution  workshop

### DIFF
--- a/01-2024-schedule/course-schedule/week-10.md
+++ b/01-2024-schedule/course-schedule/week-10.md
@@ -8,15 +8,11 @@ description: More Open Source Contributions
 
 This week, we will re-focus on Open Source Projects.&#x20;
 
-Having contributed a few weeks ago, you are to identify an Open Source project or continue working on the earlier identified project, with more impactful issues. While contributing, constantly provide updates on the progress you are making on the issues you are working on.
-
-### Monday
-
-We will start the week by having a Contributing Etiquette Workshop that will prepare us on how to contribute to Open Source Projects.&#x20;
+Having contributed a few weeks ago, you are to identify an Open Source project or continue working on the earlier identified project(s), with more impactful issues. While contributing, constantly provide updates on the progress you are making on the issues you are working on.
 
 **Design Document**
 
-After the workshop, you are expected to identify a project to work on alongside specific issues, design and submit a document for approval describing the issue and why you want to work on it and how you feel that your skills are suited to it. You must complete the design document and have it approved _before_ proceeding with any contributions.
+You are expected to deepen your contributions to the projects you already have identified or identify one to start making impactful contributions. You will identify issue(s) you intend to work on, design and submit a document for approval describing the issue and why you want to work on it and how you feel that your skills are suited to it. You must complete the design document and have it approved _before_ proceeding with any contributions.
 
 ### Personal Updates
 


### PR DESCRIPTION
- Removed the listed workshop for contributing to Open Source since it was already done in the previous week
